### PR TITLE
Add `blom7α` to the list of odd gene names

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ The CG tag was invented in order to store CIGAR strings longer than 64k operatio
 - HotDog domain - superfamily of genes/proteins https://www.wikidata.org/wiki/Q24785143 https://www.ebi.ac.uk/interpro/entry/IPR029069
 - Flower/fwe - https://flybase.org/reports/FBgn0261722.html
 - Brahma https://www.sdbonline.org/sites/fly/polycomb/brahma.htm
+- Bring lots of money (blom7α) https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2781463/ https://www.uniprot.org/uniprotkb/Q7Z7F0/entry
 
 ### Allele names
 


### PR DESCRIPTION
From [Grillari _et al_ (PMC2781463)](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2781463/):

> Here we report the identification of a previously uncharacterized KH domain protein that we termed Bring lots of money 7α (Blom7α). 

Seems like the name didn't take off and now the recommended name for the gene is `khdc4` based on the KH domain it contains, but the original one is still listed in the UniProt alternative.